### PR TITLE
Create campus service portal experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "super-system",
   "version": "1.0.0",
-  "description": "A minimal chat application inspired by QQ with real-time messaging via Server-Sent Events.",
+  "description": "A campus service portal delivering canteen hot sales, errands, and live customer support.",
   "main": "server.js",
   "scripts": {
     "start": "node server.js",

--- a/public/app.js
+++ b/public/app.js
@@ -1,196 +1,305 @@
 (() => {
-  const statusIndicator = document.getElementById('status-indicator');
-  const statusText = document.getElementById('status-text');
-  const messageList = document.getElementById('message-list');
-  const messageForm = document.getElementById('message-form');
-  const messageInput = document.getElementById('message-input');
-  const messageTemplate = document.getElementById('message-template');
-  const nameDialog = document.getElementById('name-dialog');
-  const nameForm = document.getElementById('name-form');
-  const nameInput = document.getElementById('name-input');
-  const cancelNameButton = document.getElementById('cancel-name');
-  const changeNameButton = document.getElementById('change-name');
-  const profileName = document.getElementById('profile-name');
-  const profileAvatar = document.getElementById('profile-avatar');
+  const announcementList = document.getElementById('announcement-list');
+  const serviceGrid = document.getElementById('service-grid');
+  const floorTabs = document.getElementById('floor-tabs');
+  const floorContent = document.getElementById('floor-content');
+  const ondemandGrid = document.getElementById('ondemand-grid');
+  const supportInfo = document.getElementById('support-info');
+  const supportNotice = document.getElementById('support-notice');
+  const supportButton = document.getElementById('support-button');
+  const contactButton = document.getElementById('contact-button');
+  const contactFab = document.getElementById('contact-fab');
+  const contactDialog = document.getElementById('contact-dialog');
+  const contactForm = document.getElementById('contact-form');
+  const contactCancel = document.getElementById('contact-cancel');
+  const contactHint = document.getElementById('contact-hint');
+  const contactSubmit = document.getElementById('contact-submit');
+  const toast = document.getElementById('toast');
+  const searchInput = document.getElementById('global-search');
+  const footerYear = document.getElementById('footer-year');
+  const heroBrand = document.getElementById('hero-brand');
+  const heroSlogan = document.getElementById('hero-slogan');
+  const statOrders = document.getElementById('stat-orders');
+  const statDelivery = document.getElementById('stat-delivery');
+  const statSatisfaction = document.getElementById('stat-satisfaction');
 
-  let username = localStorage.getItem('super-system-username') || '';
-  let eventSource;
-  let historyLoaded = false;
+  let dashboardData = null;
+  let activeFloorId = null;
+  let servicesCache = [];
+  let ondemandCache = [];
+  let toastTimer = null;
 
-  function updateStatus(type, text) {
-    statusIndicator.classList.remove('status-online', 'status-offline');
-    if (type === 'online') {
-      statusIndicator.classList.add('status-online');
-    } else if (type === 'offline') {
-      statusIndicator.classList.add('status-offline');
+  function setFooterYear() {
+    if (footerYear) {
+      footerYear.textContent = new Date().getFullYear();
     }
-    statusText.textContent = text;
   }
 
-  function avatarInitials(name) {
-    if (!name) return '?';
-    const trimmed = name.trim();
-    if (!trimmed) return '?';
-    return trimmed.slice(0, 1).toUpperCase();
+  function showToast(message, type = 'info') {
+    if (!toast) return;
+    clearTimeout(toastTimer);
+    toast.textContent = message;
+    toast.dataset.type = type;
+    toast.hidden = false;
+    toast.classList.add('show');
+    toastTimer = setTimeout(() => {
+      toast.classList.remove('show');
+      toastTimer = setTimeout(() => {
+        toast.hidden = true;
+      }, 220);
+    }, 3800);
   }
 
-  function setUsername(name) {
-    username = name.trim();
-    if (username) {
-      localStorage.setItem('super-system-username', username);
-      profileName.textContent = username;
-    } else {
-      localStorage.removeItem('super-system-username');
-      profileName.textContent = '未命名用户';
-    }
-    profileAvatar.textContent = avatarInitials(username);
+  function escapeHtml(input) {
+    return input
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
   }
 
-  function ensureUsername() {
-    if (username) {
-      profileAvatar.textContent = avatarInitials(username);
-      profileName.textContent = username;
+  function renderAnnouncements(list = []) {
+    if (!announcementList) return;
+    if (!list.length) {
+      announcementList.innerHTML = '<p class="empty">暂无公告</p>';
       return;
     }
 
-    openNameDialog();
-  }
-
-  function openNameDialog() {
-    if (typeof nameDialog?.showModal === 'function') {
-      nameInput.value = username;
-      nameDialog.showModal();
-      setTimeout(() => nameInput.focus(), 50);
-    } else {
-      const result = window.prompt('请输入你的昵称：', username || '');
-      if (result !== null) {
-        const trimmed = result.trim().slice(0, 32);
-        if (trimmed) {
-          setUsername(trimmed);
-        }
-      }
-    }
-  }
-
-  cancelNameButton?.addEventListener('click', () => {
-    if (typeof nameDialog?.close === 'function') {
-      nameDialog.close();
-    }
-  });
-
-  nameForm?.addEventListener('submit', event => {
-    event.preventDefault();
-    const value = nameInput.value.trim().slice(0, 32);
-    if (value) {
-      setUsername(value);
-      if (typeof nameDialog?.close === 'function') {
-        nameDialog.close();
-      }
-    }
-  });
-
-  changeNameButton?.addEventListener('click', () => {
-    openNameDialog();
-  });
-
-  function formatTimestamp(timestamp) {
-    if (!timestamp) return '';
-    try {
-      const date = new Date(timestamp);
-      return date.toLocaleString('zh-CN', {
-        hour: '2-digit',
-        minute: '2-digit',
-        month: '2-digit',
-        day: '2-digit'
-      });
-    } catch (error) {
-      return '';
-    }
-  }
-
-  function createMessageElement(message) {
-    const clone = messageTemplate.content.firstElementChild.cloneNode(true);
-    const author = clone.querySelector('.author');
-    const time = clone.querySelector('.time');
-    const content = clone.querySelector('.content');
-    author.textContent = message.user || '匿名用户';
-    time.textContent = formatTimestamp(message.timestamp);
-    content.textContent = message.text;
-    if (username && message.user === username) {
-      clone.classList.add('self');
-    }
-    return clone;
-  }
-
-  function renderMessages(messages) {
     const fragment = document.createDocumentFragment();
-    for (const message of messages) {
-      fragment.appendChild(createMessageElement(message));
-    }
-    messageList.innerHTML = '';
-    messageList.appendChild(fragment);
-    messageList.scrollTop = messageList.scrollHeight;
+    list.forEach(item => {
+      const card = document.createElement('article');
+      card.className = `announcement-card announcement-${item.level || 'info'}`;
+      card.innerHTML = `
+        <header>
+          <span class="announcement-date">${escapeHtml(item.date || '')}</span>
+          <h3>${escapeHtml(item.title || '')}</h3>
+        </header>
+        <p>${escapeHtml(item.description || '')}</p>
+      `;
+      fragment.appendChild(card);
+    });
+    announcementList.innerHTML = '';
+    announcementList.appendChild(fragment);
   }
 
-  function appendMessage(message) {
-    messageList.appendChild(createMessageElement(message));
-    messageList.scrollTop = messageList.scrollHeight;
+  function createServiceCard(item) {
+    const card = document.createElement('article');
+    card.className = 'service-card';
+    card.style.setProperty('--accent', item.accent || 'linear-gradient(135deg,#84fab0,#8fd3f4)');
+    card.innerHTML = `
+      <span class="service-icon" aria-hidden="true">${escapeHtml(item.icon || '📦')}</span>
+      <div>
+        <h3>${escapeHtml(item.name || '')}</h3>
+        <p>${escapeHtml(item.description || '')}</p>
+      </div>
+      <button type="button" class="service-action" aria-label="立即前往${escapeHtml(item.name || '')}">
+        进入
+      </button>
+    `;
+    return card;
   }
 
-  function connect() {
-    if (eventSource) {
-      eventSource.close();
-    }
-
-    updateStatus('offline', '正在连接...');
-    eventSource = new EventSource('/events');
-
-    eventSource.addEventListener('open', () => {
-      updateStatus('online', '已连接');
-    });
-
-    eventSource.addEventListener('error', () => {
-      updateStatus('offline', '连接异常，正在重试...');
-    });
-
-    eventSource.addEventListener('history', event => {
-      try {
-        const payload = JSON.parse(event.data || '[]');
-        renderMessages(payload);
-        historyLoaded = true;
-      } catch (error) {
-        console.error('无法解析历史记录', error);
-      }
-    });
-
-    eventSource.addEventListener('message', event => {
-      try {
-        const payload = JSON.parse(event.data || '{}');
-        if (!historyLoaded) {
-          return;
-        }
-        appendMessage(payload);
-      } catch (error) {
-        console.error('无法解析消息', error);
-      }
-    });
-  }
-
-  messageForm?.addEventListener('submit', async event => {
-    event.preventDefault();
-    const text = messageInput.value.trim();
-    if (!text) {
+  function renderServices(list = []) {
+    if (!serviceGrid) return;
+    if (!list.length) {
+      serviceGrid.innerHTML = '<p class="empty">暂无匹配的服务，换个关键词试试。</p>';
       return;
     }
+    const fragment = document.createDocumentFragment();
+    list.forEach(item => fragment.appendChild(createServiceCard(item)));
+    serviceGrid.innerHTML = '';
+    serviceGrid.appendChild(fragment);
+  }
 
-    const payload = {
-      user: username || '匿名用户',
-      text
-    };
+  function renderFloorTabs(floors = []) {
+    if (!floorTabs) return;
+    const fragment = document.createDocumentFragment();
+    floors.forEach((floor, index) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'floor-tab';
+      button.textContent = floor.name;
+      button.dataset.floorId = floor.id;
+      button.setAttribute('role', 'tab');
+      button.setAttribute('aria-selected', index === 0 ? 'true' : 'false');
+      button.addEventListener('click', () => setActiveFloor(floor.id));
+      fragment.appendChild(button);
+    });
+    floorTabs.innerHTML = '';
+    floorTabs.appendChild(fragment);
+    if (floors.length) {
+      setActiveFloor(floors[0].id);
+    }
+  }
 
-    messageForm.classList.add('pending');
+  function createStallCard(stall) {
+    const card = document.createElement('article');
+    card.className = 'stall-card';
+    const tagList = (stall.tags || []).map(tag => `<span>${escapeHtml(tag)}</span>`).join('');
+    card.innerHTML = `
+      <div class="stall-title">
+        <h3>${escapeHtml(stall.name || '')}</h3>
+        <span class="stall-price">${escapeHtml(stall.price || '')}</span>
+      </div>
+      <p class="stall-meta">今日销量 <strong>${escapeHtml(String(stall.soldToday || 0))}</strong> 份</p>
+      <div class="stall-tags">${tagList}</div>
+      <button type="button" class="stall-action">立即下单</button>
+    `;
+    return card;
+  }
+
+  function setActiveFloor(floorId) {
+    if (!dashboardData || !floorContent) return;
+    if (activeFloorId === floorId) return;
+    activeFloorId = floorId;
+    const floors = dashboardData.featuredFloors || [];
+    const current = floors.find(floor => floor.id === floorId);
+    if (!current) return;
+
+    const tabButtons = floorTabs?.querySelectorAll('.floor-tab');
+    tabButtons?.forEach(btn => {
+      const selected = btn.dataset.floorId === floorId;
+      btn.classList.toggle('active', selected);
+      btn.setAttribute('aria-selected', selected ? 'true' : 'false');
+    });
+
+    const fragment = document.createDocumentFragment();
+    const infoCard = document.createElement('div');
+    infoCard.className = 'floor-summary';
+    infoCard.innerHTML = `
+      <div>
+        <h3>${escapeHtml(current.name || '')}</h3>
+        <p>${escapeHtml(current.waiting || '')}</p>
+      </div>
+      <div>
+        <p class="floor-distance">${escapeHtml(current.distance || '')}</p>
+        <p class="floor-highlight">亮点：${escapeHtml((current.highlights || []).join('、'))}</p>
+      </div>
+    `;
+    fragment.appendChild(infoCard);
+
+    (current.stalls || []).forEach(stall => fragment.appendChild(createStallCard(stall)));
+    if (!current.stalls || !current.stalls.length) {
+      const empty = document.createElement('p');
+      empty.className = 'empty';
+      empty.textContent = '该楼层暂未开放线上订餐';
+      fragment.appendChild(empty);
+    }
+    floorContent.innerHTML = '';
+    floorContent.appendChild(fragment);
+  }
+
+  function createOndemandCard(item) {
+    const card = document.createElement('article');
+    card.className = 'ondemand-card';
+    card.innerHTML = `
+      <div class="ondemand-icon" aria-hidden="true">${escapeHtml(item.icon || '🛵')}</div>
+      <div class="ondemand-body">
+        <div class="ondemand-title">
+          <h3>${escapeHtml(item.name || '')}</h3>
+          <span>${escapeHtml(item.price || '')}</span>
+        </div>
+        <p>${escapeHtml(item.description || '')}</p>
+        <p class="ondemand-meta">预计：${escapeHtml(item.eta || '')}</p>
+      </div>
+      <button type="button" class="ondemand-action">立即预约</button>
+    `;
+    return card;
+  }
+
+  function renderOndemand(list = []) {
+    if (!ondemandGrid) return;
+    if (!list.length) {
+      ondemandGrid.innerHTML = '<p class="empty">暂未找到相关跑腿服务。</p>';
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    list.forEach(item => fragment.appendChild(createOndemandCard(item)));
+    ondemandGrid.innerHTML = '';
+    ondemandGrid.appendChild(fragment);
+  }
+
+  function renderSupport(contact = {}) {
+    if (!supportInfo) return;
+    const { hotline, wechat, email, serviceHours, location, notice } = contact;
+    supportNotice.textContent = notice || '提交后我们将尽快联系您。';
+    contactHint.textContent = serviceHours ? `客服在线时间：${serviceHours}` : '';
+
+    const supportItems = [
+      { icon: '📞', label: '客服热线', value: hotline },
+      { icon: '💬', label: '企业微信', value: wechat },
+      { icon: '📧', label: '服务邮箱', value: email },
+      { icon: '📍', label: '线下客服点', value: location }
+    ].filter(item => item.value);
+
+    const fragment = document.createDocumentFragment();
+    supportItems.forEach(item => {
+      const row = document.createElement('div');
+      row.className = 'support-row';
+      row.innerHTML = `
+        <span class="support-icon" aria-hidden="true">${escapeHtml(item.icon)}</span>
+        <div>
+          <p class="support-label">${escapeHtml(item.label)}</p>
+          <p class="support-value">${escapeHtml(item.value)}</p>
+        </div>
+      `;
+      fragment.appendChild(row);
+    });
+    supportInfo.innerHTML = '';
+    supportInfo.appendChild(fragment);
+  }
+
+  function filterDataByKeyword(keyword) {
+    if (!keyword) {
+      renderServices(servicesCache);
+      renderOndemand(ondemandCache);
+      return;
+    }
+    const lower = keyword.toLowerCase();
+    const filteredServices = servicesCache.filter(item => {
+      const text = `${item.name || ''} ${item.description || ''}`.toLowerCase();
+      return text.includes(lower);
+    });
+    const filteredOndemand = ondemandCache.filter(item => {
+      const text = `${item.name || ''} ${item.description || ''} ${item.eta || ''}`.toLowerCase();
+      return text.includes(lower);
+    });
+    renderServices(filteredServices);
+    renderOndemand(filteredOndemand);
+  }
+
+  function openContactDialog() {
+    if (!contactDialog) return;
+    if (typeof contactDialog.showModal === 'function') {
+      contactDialog.showModal();
+    } else {
+      contactDialog.setAttribute('open', '');
+    }
+    requestAnimationFrame(() => {
+      document.getElementById('contact-name')?.focus();
+    });
+  }
+
+  function closeContactDialog() {
+    if (!contactDialog) return;
+    if (typeof contactDialog.close === 'function') {
+      contactDialog.close();
+    } else {
+      contactDialog.removeAttribute('open');
+    }
+  }
+
+  async function submitContactForm(event) {
+    event.preventDefault();
+    if (!contactForm) return;
+    const formData = new FormData(contactForm);
+    const payload = Object.fromEntries(formData.entries());
+    contactSubmit.disabled = true;
+    contactSubmit.textContent = '提交中...';
+
     try {
-      const response = await fetch('/message', {
+      const response = await fetch('/api/contact', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'
@@ -198,28 +307,88 @@
         body: JSON.stringify(payload)
       });
 
+      const result = await response.json().catch(() => ({}));
       if (!response.ok) {
-        const result = await response.json().catch(() => ({}));
-        updateStatus('offline', result.error || '发送失败，请稍后再试');
-      } else {
-        messageInput.value = '';
-        updateStatus('online', '已连接');
+        throw new Error(result.error || '提交失败，请稍后再试');
       }
+
+      showToast(result.message || '客服已收到您的消息，我们会尽快回复。', 'success');
+      closeContactDialog();
+      contactForm.reset();
     } catch (error) {
-      updateStatus('offline', '网络异常，消息未发送');
+      showToast(error.message || '网络异常，请稍后再试', 'error');
     } finally {
-      messageForm.classList.remove('pending');
-      messageInput.focus();
+      contactSubmit.disabled = false;
+      contactSubmit.textContent = '提交咨询';
     }
-  });
+  }
 
-  window.addEventListener('focus', () => {
-    if (!eventSource || eventSource.readyState === EventSource.CLOSED) {
-      connect();
+  async function loadDashboard() {
+    try {
+      const response = await fetch('/api/home');
+      if (!response.ok) {
+        throw new Error('无法获取校园服务数据');
+      }
+      dashboardData = await response.json();
+      servicesCache = dashboardData.categories || [];
+      ondemandCache = dashboardData.onDemandServices || [];
+
+      if (heroBrand && dashboardData.hero?.brand) {
+        heroBrand.textContent = dashboardData.hero.brand;
+      }
+      if (heroSlogan && dashboardData.hero?.slogan) {
+        heroSlogan.textContent = dashboardData.hero.slogan;
+      }
+      if (statOrders) {
+        const orders = dashboardData.hero?.stats?.completedOrdersToday;
+        statOrders.textContent = orders ? `${orders} 单` : '—';
+      }
+      if (statDelivery) {
+        const delivery = dashboardData.hero?.stats?.averageDeliveryMinutes;
+        statDelivery.textContent = delivery ? `${delivery} 分钟` : '—';
+      }
+      if (statSatisfaction) {
+        const satisfaction = dashboardData.hero?.stats?.serviceSatisfaction;
+        statSatisfaction.textContent = satisfaction ? `${satisfaction}%` : '—';
+      }
+
+      renderAnnouncements(dashboardData.announcements);
+      renderServices(servicesCache);
+      renderFloorTabs(dashboardData.featuredFloors);
+      renderOndemand(ondemandCache);
+      renderSupport(dashboardData.contact);
+    } catch (error) {
+      console.error(error);
+      showToast(error.message || '系统繁忙，请稍后再试', 'error');
+      if (announcementList) {
+        announcementList.innerHTML = '<p class="empty">暂时无法获取公告，请稍后刷新。</p>';
+      }
     }
-  });
+  }
 
-  ensureUsername();
-  setUsername(username);
-  connect();
+  function bindEvents() {
+    contactButton?.addEventListener('click', openContactDialog);
+    contactFab?.addEventListener('click', openContactDialog);
+    supportButton?.addEventListener('click', openContactDialog);
+    contactCancel?.addEventListener('click', () => {
+      contactForm?.reset();
+      closeContactDialog();
+    });
+    contactForm?.addEventListener('submit', submitContactForm);
+    contactDialog?.addEventListener('close', () => {
+      contactForm?.reset();
+      contactSubmit.disabled = false;
+      contactSubmit.textContent = '提交咨询';
+    });
+    searchInput?.addEventListener('input', event => {
+      const keyword = event.target.value.trim();
+      filterDataByKeyword(keyword);
+    });
+  }
+
+  window.addEventListener('DOMContentLoaded', () => {
+    setFooterYear();
+    bindEvents();
+    loadDashboard();
+  });
 })();

--- a/public/index.html
+++ b/public/index.html
@@ -3,88 +3,161 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Super System Chat</title>
+    <title>云速达 · 微校园服务中心</title>
+    <meta
+      name="description"
+      content="云速达微校园，为师生提供食堂订餐、跑腿代办、文件打印、快递到寝等一站式校园服务。"
+    />
     <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Noto+Sans+SC:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
-    <div class="app-shell">
-      <header class="app-header">
-        <div>
-          <h1>Super System Chat</h1>
-          <p class="subtitle">一个简洁的在线聊天室，灵感来自 QQ</p>
+    <div class="page-shell">
+      <header class="hero" id="hero">
+        <div class="hero-info">
+          <p class="brand-pill" id="hero-brand">云速达 · 微校园</p>
+          <h1 id="hero-slogan">一站式校园生活服务，用心守护每一个紧急时刻</h1>
+          <p class="hero-subtitle">
+            校园外卖、快递代取、打印复印、教务跑腿……一部手机即可搞定，实时追踪进度，安心托付给我们。
+          </p>
+          <div class="hero-actions">
+            <div class="search-box">
+              <span aria-hidden="true">🔍</span>
+              <input
+                type="search"
+                id="global-search"
+                placeholder="搜索：瓦香鸡、快递代取、打印..."
+                aria-label="搜索校园服务"
+              />
+            </div>
+            <button class="primary" id="contact-button" type="button">立即联系客服</button>
+          </div>
         </div>
-        <div class="connection">
-          <span class="status-indicator" id="status-indicator"></span>
-          <span id="status-text">正在连接...</span>
+        <div class="hero-stats" id="hero-stats">
+          <div class="stat-card">
+            <p class="stat-label">今日完成</p>
+            <p class="stat-value" id="stat-orders">0 单</p>
+            <p class="stat-desc">骑手全程动态可追踪</p>
+          </div>
+          <div class="stat-card">
+            <p class="stat-label">平均送达</p>
+            <p class="stat-value" id="stat-delivery">0 分钟</p>
+            <p class="stat-desc">高峰期自动调度骑手</p>
+          </div>
+          <div class="stat-card">
+            <p class="stat-label">满意度</p>
+            <p class="stat-value" id="stat-satisfaction">0%</p>
+            <p class="stat-desc">服务专员 7×16 小时守候</p>
+          </div>
         </div>
       </header>
-      <main class="app-main">
-        <aside class="app-aside">
-          <section class="profile-card">
-            <h2>我的资料</h2>
-            <div class="profile-info">
-              <div class="avatar" id="profile-avatar" aria-hidden="true"></div>
-              <div>
-                <p class="nickname" id="profile-name">未命名用户</p>
-                <button id="change-name" type="button" class="link-button">修改昵称</button>
-              </div>
+
+      <main class="page-main">
+        <section class="announcement-section">
+          <div class="section-header">
+            <h2>校园公告</h2>
+            <a class="link" href="#" aria-label="查看更多公告">查看更多</a>
+          </div>
+          <div class="announcement-list" id="announcement-list"></div>
+        </section>
+
+        <section class="service-section">
+          <div class="section-header">
+            <h2>热门服务导航</h2>
+            <p class="section-subtitle">常用服务一键直达，吃喝玩乐、学习生活全覆盖</p>
+          </div>
+          <div class="service-grid" id="service-grid" aria-live="polite"></div>
+        </section>
+
+        <section class="canteen-section">
+          <div class="section-header">
+            <h2>食堂热销榜</h2>
+            <p class="section-subtitle">实时刷新食堂档口销量，先人一步抢热门</p>
+          </div>
+          <div class="floor-tabs" id="floor-tabs" role="tablist" aria-label="食堂楼层选择"></div>
+          <div class="floor-content" id="floor-content"></div>
+        </section>
+
+        <section class="ondemand-section">
+          <div class="section-header">
+            <h2>校园代办 &amp; 跑腿</h2>
+            <p class="section-subtitle">急您所急，专业跑腿小队随叫随到</p>
+          </div>
+          <div class="ondemand-grid" id="ondemand-grid"></div>
+        </section>
+
+        <section class="support-section" id="support-section">
+          <div class="support-card" id="support-card">
+            <div>
+              <h2>客服中心</h2>
+              <p class="support-tip" id="support-notice">提交表单后，客服将在 10 分钟内与您取得联系。</p>
             </div>
-          </section>
-          <section class="tips">
-            <h2>温馨提示</h2>
-            <ul>
-              <li>设置一个好记的昵称，朋友们更容易认出你。</li>
-              <li>消息即时同步给所有在线用户。</li>
-              <li>如果长时间无响应，可以尝试刷新页面重新连接。</li>
-            </ul>
-          </section>
-        </aside>
-        <section class="chat-panel">
-          <ol class="message-list" id="message-list" aria-live="polite"></ol>
+            <div class="support-info" id="support-info"></div>
+            <button class="secondary" id="support-button" type="button">我要咨询</button>
+          </div>
         </section>
       </main>
-      <form id="message-form" class="message-form" autocomplete="off">
-        <label class="sr-only" for="message-input">消息内容</label>
-        <input
-          id="message-input"
-          name="message"
-          type="text"
-          placeholder="输入聊天内容，按回车发送"
-          maxlength="500"
-          required
-        />
-        <button type="submit">发送</button>
-      </form>
+
+      <footer class="page-footer">
+        <p>© <span id="footer-year"></span> 云速达 · 微校园服务中心</p>
+        <p class="footer-links">
+          <a href="#">服务协议</a>
+          <span>·</span>
+          <a href="#">隐私政策</a>
+          <span>·</span>
+          <a href="#">校园合作</a>
+        </p>
+      </footer>
     </div>
 
-    <dialog id="name-dialog" class="name-dialog">
-      <form method="dialog" id="name-form">
-        <h2>欢迎来到 Super System Chat</h2>
-        <p>请输入你的昵称：</p>
-        <input
-          id="name-input"
-          name="name"
-          type="text"
-          placeholder="例如：小明"
-          maxlength="32"
-          required
-        />
-        <menu>
-          <button value="cancel" type="button" id="cancel-name">稍后再说</button>
-          <button value="confirm" id="confirm-name" type="submit">确认</button>
-        </menu>
+    <button class="contact-fab" id="contact-fab" type="button" aria-label="联系客服">
+      <span aria-hidden="true">💬</span>
+      <span>客服</span>
+    </button>
+
+    <dialog id="contact-dialog" class="contact-dialog">
+      <form method="dialog" class="contact-form" id="contact-form">
+        <header>
+          <h2>联系云速达客服</h2>
+          <p>留下您的需求，值班客服将尽快与您取得联系。</p>
+        </header>
+        <label class="input-field">
+          <span>您的姓名或昵称</span>
+          <input type="text" name="name" id="contact-name" maxlength="32" placeholder="例如：信息院-小李" required />
+        </label>
+        <label class="input-field">
+          <span>手机 / 短号</span>
+          <input type="tel" name="phone" id="contact-phone" maxlength="20" placeholder="方便我们回电" />
+        </label>
+        <label class="input-field">
+          <span>需要咨询的服务</span>
+          <input type="text" name="serviceType" id="contact-service" maxlength="50" placeholder="如：食堂订餐、快递代取" />
+        </label>
+        <label class="input-field">
+          <span>具体情况</span>
+          <textarea
+            name="message"
+            id="contact-message"
+            rows="4"
+            maxlength="500"
+            placeholder="请尽可能详细描述您的需求或遇到的问题"
+            required
+          ></textarea>
+        </label>
+        <footer class="dialog-actions">
+          <button value="cancel" type="button" class="ghost" id="contact-cancel">稍后再说</button>
+          <button value="submit" type="submit" class="primary" id="contact-submit">提交咨询</button>
+        </footer>
+        <p class="dialog-hint" id="contact-hint">客服在线时间：07:30 - 23:30</p>
       </form>
     </dialog>
 
-    <template id="message-template">
-      <li class="message">
-        <div class="meta">
-          <span class="author"></span>
-          <span class="time"></span>
-        </div>
-        <p class="content"></p>
-      </li>
-    </template>
+    <div class="toast" id="toast" role="status" aria-live="polite" hidden></div>
 
     <script src="app.js" defer></script>
   </body>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,12 +1,22 @@
 :root {
-  color-scheme: light dark;
-  --bg: #f5f7fb;
-  --panel: #ffffff;
-  --accent: #3370ff;
-  --text: #1f2329;
-  --muted: #6b7785;
-  --border: rgba(31, 35, 41, 0.1);
-  font-family: 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+  --bg: #f5f7ff;
+  --card: #ffffff;
+  --text: #202332;
+  --text-muted: #5f667a;
+  --primary: #4c6ef5;
+  --primary-dark: #364fc7;
+  --primary-light: rgba(76, 110, 245, 0.14);
+  --warning: #f59f00;
+  --success: #2f9e44;
+  --info: #4dabf7;
+  --danger: #f03e3e;
+  --radius-lg: 24px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --shadow-soft: 0 20px 45px rgba(32, 35, 50, 0.12);
+  --shadow-card: 0 16px 30px rgba(32, 35, 50, 0.08);
+  font-family: 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+  color-scheme: light;
 }
 
 * {
@@ -16,311 +26,771 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at top, rgba(51, 112, 255, 0.12), transparent 60%), var(--bg);
+  background: linear-gradient(180deg, #f3f6ff 0%, #eef1ff 60%, #f9fbff 100%);
   color: var(--text);
 }
 
-.app-shell {
-  max-width: 1080px;
-  margin: 0 auto;
-  padding: 24px;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  min-height: 100vh;
+a {
+  color: inherit;
+  text-decoration: none;
 }
 
-.app-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  background: var(--panel);
-  border-radius: 16px;
-  padding: 20px 24px;
-  box-shadow: 0 16px 40px rgba(51, 112, 255, 0.12);
-  border: 1px solid var(--border);
-}
-
-.app-header h1 {
-  margin: 0;
-  font-size: 28px;
-}
-
-.subtitle {
-  margin: 4px 0 0;
-  color: var(--muted);
-  font-size: 14px;
-}
-
-.connection {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 14px;
-  color: var(--muted);
-}
-
-.status-indicator {
-  display: inline-flex;
-  width: 12px;
-  height: 12px;
-  border-radius: 50%;
-  background: #d1d5db;
-  box-shadow: 0 0 0 3px rgba(51, 112, 255, 0.1);
-}
-
-.status-online {
-  background: #22c55e;
-}
-
-.status-offline {
-  background: #f97316;
-}
-
-.app-main {
-  display: grid;
-  grid-template-columns: 280px 1fr;
-  gap: 16px;
-  flex: 1;
-}
-
-.app-aside,
-.chat-panel {
-  background: var(--panel);
-  border-radius: 16px;
-  padding: 20px;
-  border: 1px solid var(--border);
-  box-shadow: 0 16px 40px rgba(31, 41, 55, 0.06);
-}
-
-.profile-card h2,
-.tips h2 {
-  margin-top: 0;
-  font-size: 18px;
-}
-
-.profile-info {
-  display: flex;
-  gap: 16px;
-  align-items: center;
-}
-
-.avatar {
-  width: 64px;
-  height: 64px;
-  border-radius: 20px;
-  background: linear-gradient(135deg, #3370ff, #a855f7);
-  display: grid;
-  place-items: center;
-  color: white;
-  font-weight: 600;
-  font-size: 24px;
-  text-transform: uppercase;
-  box-shadow: 0 12px 24px rgba(51, 112, 255, 0.35);
-}
-
-.nickname {
-  margin: 0 0 8px;
-  font-size: 20px;
-}
-
-.link-button {
-  background: none;
-  border: none;
-  color: var(--accent);
-  cursor: pointer;
-  padding: 0;
-  font-size: 14px;
-}
-
-.link-button:hover,
-.link-button:focus {
+a:hover,
+a:focus {
   text-decoration: underline;
 }
 
-.tips ul {
-  padding-left: 18px;
-  margin: 12px 0 0;
-  color: var(--muted);
-  font-size: 14px;
-  line-height: 1.6;
-}
-
-.chat-panel {
+.page-shell {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 32px 24px 48px;
   display: flex;
   flex-direction: column;
+  gap: 32px;
+}
+
+.hero {
+  background: radial-gradient(circle at 10% 20%, rgba(76, 110, 245, 0.25), transparent 60%),
+    radial-gradient(circle at 80% 20%, rgba(74, 222, 255, 0.25), transparent 55%),
+    var(--card);
+  border-radius: var(--radius-lg);
+  padding: 40px;
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 32px;
+  box-shadow: var(--shadow-soft);
+  position: relative;
   overflow: hidden;
 }
 
-.message-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  overflow-y: auto;
+.hero::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(76, 110, 245, 0.12);
+  pointer-events: none;
+}
+
+.hero-info h1 {
+  margin: 12px 0 16px;
+  font-size: clamp(28px, 4vw, 42px);
+  line-height: 1.2;
+}
+
+.hero-subtitle {
+  margin: 0 0 28px;
+  color: var(--text-muted);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.brand-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  background: rgba(76, 110, 245, 0.12);
+  color: var(--primary);
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+}
+
+.search-box {
   flex: 1;
+  min-width: 240px;
   display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.message {
-  background: rgba(51, 112, 255, 0.08);
-  border-radius: 12px;
-  padding: 12px 16px;
-  display: flex;
-  flex-direction: column;
+  align-items: center;
   gap: 8px;
-  align-self: flex-start;
-  max-width: 70ch;
+  padding: 10px 16px;
+  background: #fff;
+  border-radius: 999px;
+  border: 1px solid rgba(76, 110, 245, 0.18);
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.04);
 }
 
-.message.self {
-  background: rgba(34, 197, 94, 0.15);
-  align-self: flex-end;
+.search-box input {
+  border: none;
+  flex: 1;
+  font-size: 15px;
+  font-family: inherit;
+  background: transparent;
+  outline: none;
 }
 
-.meta {
-  display: flex;
-  justify-content: space-between;
-  font-size: 12px;
-  color: var(--muted);
-  gap: 8px;
+.hero-stats {
+  display: grid;
+  gap: 18px;
 }
 
-.content {
+.stat-card {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: var(--radius-md);
+  padding: 20px 24px;
+  box-shadow: var(--shadow-card);
+  border: 1px solid rgba(76, 110, 245, 0.1);
+  backdrop-filter: blur(6px);
+}
+
+.stat-label {
   margin: 0;
-  white-space: pre-wrap;
-  word-break: break-word;
+  color: var(--text-muted);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+
+.stat-value {
+  margin: 10px 0 8px;
+  font-size: 28px;
+  font-weight: 700;
+}
+
+.stat-desc {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+.page-main {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.section-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.section-header h2 {
+  margin: 0;
+  font-size: 24px;
+}
+
+.section-subtitle {
+  margin: 0;
+  color: var(--text-muted);
   font-size: 15px;
 }
 
-.message-form {
+.link {
+  color: var(--primary);
+  font-weight: 500;
+}
+
+.announcement-section,
+.service-section,
+.canteen-section,
+.ondemand-section,
+.support-section {
+  background: var(--card);
+  border-radius: var(--radius-lg);
+  padding: 28px 32px;
+  box-shadow: var(--shadow-card);
+  position: relative;
+  overflow: hidden;
+}
+
+.announcement-section::before,
+.service-section::before,
+.canteen-section::before,
+.ondemand-section::before,
+.support-section::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  border: 1px solid rgba(76, 110, 245, 0.08);
+  pointer-events: none;
+}
+
+.announcement-list {
   display: grid;
-  grid-template-columns: 1fr auto;
+  gap: 16px;
+}
+
+.announcement-card {
+  padding: 18px 22px;
+  border-radius: var(--radius-md);
+  background: rgba(244, 246, 255, 0.8);
+  border: 1px solid rgba(76, 110, 245, 0.1);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.announcement-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 18px 26px rgba(32, 35, 50, 0.12);
+}
+
+.announcement-card h3 {
+  margin: 4px 0 8px;
+  font-size: 18px;
+}
+
+.announcement-card p {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.announcement-date {
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+.announcement-info {
+  background: rgba(77, 171, 247, 0.12);
+}
+
+.announcement-success {
+  background: rgba(47, 158, 68, 0.12);
+}
+
+.announcement-warning {
+  background: rgba(245, 159, 0, 0.12);
+}
+
+.service-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
+  gap: 18px;
+}
+
+.service-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
   gap: 12px;
-  background: var(--panel);
-  padding: 16px 20px;
-  border-radius: 16px;
-  border: 1px solid var(--border);
-  box-shadow: 0 12px 30px rgba(51, 112, 255, 0.12);
+  padding: 20px 18px;
+  border-radius: var(--radius-md);
+  background: var(--card);
+  border: 1px solid rgba(32, 35, 50, 0.08);
+  box-shadow: inset 0 0 0 2px var(--primary-light);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.message-form input {
-  border: 1px solid var(--border);
-  border-radius: 12px;
-  padding: 12px 16px;
-  font-size: 16px;
-  transition: border-color 0.2s ease;
+.service-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  background: var(--accent, rgba(76, 110, 245, 0.16));
+  opacity: 0.16;
+  z-index: 0;
 }
 
-.message-form input:focus {
-  outline: none;
-  border-color: var(--accent);
-  box-shadow: 0 0 0 3px rgba(51, 112, 255, 0.15);
+.service-card > * {
+  position: relative;
+  z-index: 1;
 }
 
-.message-form button {
-  background: var(--accent);
-  color: #ffffff;
+.service-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--shadow-card);
+}
+
+.service-icon {
+  font-size: 28px;
+}
+
+.service-card h3 {
+  margin: 0 0 6px;
+  font-size: 18px;
+}
+
+.service-card p {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.service-action {
   border: none;
+  background: rgba(255, 255, 255, 0.8);
+  color: var(--primary);
+  font-weight: 600;
+  padding: 8px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.service-action:hover {
+  background: rgba(76, 110, 245, 0.15);
+}
+
+.floor-tabs {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 20px;
+}
+
+.floor-tab {
+  border: 1px solid rgba(76, 110, 245, 0.3);
+  background: rgba(76, 110, 245, 0.08);
+  color: var(--primary);
+  padding: 8px 18px;
+  border-radius: 999px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.floor-tab.active,
+.floor-tab:hover {
+  background: var(--primary);
+  color: #fff;
+}
+
+.floor-content {
+  display: grid;
+  gap: 18px;
+}
+
+.floor-summary {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+  padding: 18px 22px;
+  border-radius: var(--radius-md);
+  background: rgba(76, 110, 245, 0.08);
+  border: 1px solid rgba(76, 110, 245, 0.16);
+}
+
+.floor-summary h3 {
+  margin: 0 0 6px;
+}
+
+.floor-summary p {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.floor-distance {
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.floor-highlight {
+  font-size: 14px;
+}
+
+.stall-card {
+  display: grid;
+  gap: 12px;
+  padding: 20px 22px;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid rgba(32, 35, 50, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(76, 110, 245, 0.08);
+}
+
+.stall-title {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: baseline;
+}
+
+.stall-title h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.stall-price {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.stall-meta {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.stall-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.stall-tags span {
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: rgba(76, 110, 245, 0.12);
+  color: var(--primary-dark);
+  font-size: 13px;
+}
+
+.stall-action {
+  justify-self: start;
+  border: none;
+  background: var(--primary);
+  color: #fff;
+  padding: 10px 18px;
   border-radius: 12px;
-  padding: 0 24px;
-  font-size: 16px;
   font-weight: 600;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.message-form button:hover,
-.message-form button:focus {
-  transform: translateY(-1px);
-  box-shadow: 0 10px 20px rgba(51, 112, 255, 0.25);
+.stall-action:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 20px rgba(76, 110, 245, 0.25);
 }
 
-.name-dialog {
-  border: none;
-  border-radius: 16px;
-  padding: 24px;
-  max-width: 360px;
-  width: 90vw;
-  box-shadow: 0 24px 60px rgba(31, 41, 55, 0.25);
+.ondemand-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 18px;
 }
 
-.name-dialog::backdrop {
-  background: rgba(15, 23, 42, 0.4);
+.ondemand-card {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 14px;
+  padding: 20px 22px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(32, 35, 50, 0.08);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(249, 249, 255, 0.9));
+  box-shadow: inset 0 0 0 1px rgba(76, 110, 245, 0.08);
 }
 
-.name-dialog h2 {
-  margin-top: 0;
+.ondemand-icon {
+  font-size: 28px;
 }
 
-.name-dialog input {
-  width: 100%;
-  margin: 12px 0 16px;
-  padding: 12px;
-  border-radius: 10px;
-  border: 1px solid var(--border);
-  font-size: 16px;
-}
-
-.name-dialog menu {
+.ondemand-title {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: baseline;
   gap: 12px;
-  padding: 0;
 }
 
-.name-dialog button {
-  border-radius: 10px;
-  padding: 10px 18px;
+.ondemand-title h3 {
+  margin: 0;
+  font-size: 18px;
+}
+
+.ondemand-title span {
+  color: var(--primary);
+  font-weight: 600;
+}
+
+.ondemand-card p {
+  margin: 6px 0;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+.ondemand-meta {
+  font-weight: 500;
+  color: var(--primary);
+}
+
+.ondemand-action {
+  align-self: center;
   border: none;
+  background: rgba(76, 110, 245, 0.1);
+  color: var(--primary);
+  padding: 10px 16px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.ondemand-action:hover {
+  background: rgba(76, 110, 245, 0.2);
+}
+
+.support-card {
+  display: grid;
+  gap: 18px;
+  background: linear-gradient(135deg, rgba(76, 110, 245, 0.1), rgba(76, 110, 245, 0.02));
+  padding: 28px 26px;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(76, 110, 245, 0.16);
+}
+
+.support-info {
+  display: grid;
+  gap: 12px;
+}
+
+.support-row {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(76, 110, 245, 0.12);
+}
+
+.support-icon {
+  font-size: 22px;
+}
+
+.support-label {
+  margin: 0;
+  font-weight: 600;
+}
+
+.support-value {
+  margin: 2px 0 0;
+  color: var(--text-muted);
+}
+
+.support-tip {
+  margin: 0;
+  color: var(--text-muted);
+}
+
+.page-footer {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 14px;
+  display: grid;
+  gap: 8px;
+}
+
+.footer-links {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+}
+
+button {
+  font-family: inherit;
+}
+
+button.primary {
+  background: var(--primary);
+  color: #fff;
+  border: none;
+  border-radius: 12px;
+  padding: 12px 22px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 14px 30px rgba(76, 110, 245, 0.24);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button.primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 34px rgba(76, 110, 245, 0.28);
+}
+
+button.secondary {
+  justify-self: start;
+  background: rgba(76, 110, 245, 0.1);
+  color: var(--primary);
+  border: none;
+  border-radius: 12px;
+  padding: 10px 20px;
+  font-weight: 600;
   cursor: pointer;
 }
 
-#cancel-name {
-  background: rgba(31, 35, 41, 0.08);
+button.secondary:hover {
+  background: rgba(76, 110, 245, 0.2);
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--text-muted);
+  border: none;
+  padding: 10px 16px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+button.ghost:hover {
   color: var(--text);
 }
 
-#confirm-name {
-  background: var(--accent);
+.contact-fab {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: var(--primary);
   color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 14px 18px;
+  font-weight: 600;
+  box-shadow: 0 16px 36px rgba(76, 110, 245, 0.35);
+  cursor: pointer;
+  z-index: 20;
 }
 
-.sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
+.contact-dialog {
+  border: none;
+  border-radius: var(--radius-md);
   padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  border: 0;
+  width: min(460px, 92vw);
+  box-shadow: 0 28px 60px rgba(32, 35, 50, 0.35);
 }
 
-@media (max-width: 900px) {
-  .app-main {
+.contact-dialog::backdrop {
+  background: rgba(15, 20, 40, 0.4);
+}
+
+.contact-form {
+  display: grid;
+  gap: 18px;
+  padding: 28px;
+}
+
+.contact-form header h2 {
+  margin: 0 0 6px;
+}
+
+.input-field {
+  display: grid;
+  gap: 8px;
+  font-size: 14px;
+  color: var(--text-muted);
+}
+
+.input-field input,
+.input-field textarea {
+  width: 100%;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(32, 35, 50, 0.15);
+  font-size: 15px;
+  font-family: inherit;
+  resize: vertical;
+}
+
+.input-field input:focus,
+.input-field textarea:focus {
+  outline: 2px solid rgba(76, 110, 245, 0.35);
+  border-color: rgba(76, 110, 245, 0.5);
+}
+
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+.dialog-hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 13px;
+  text-align: right;
+}
+
+.toast {
+  position: fixed;
+  left: 50%;
+  bottom: 32px;
+  transform: translate(-50%, 20px);
+  padding: 14px 20px;
+  border-radius: 14px;
+  background: rgba(32, 35, 50, 0.88);
+  color: #fff;
+  font-size: 15px;
+  opacity: 0;
+  transition: opacity 0.22s ease, transform 0.22s ease;
+  z-index: 40;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.toast[data-type='success'] {
+  background: rgba(47, 158, 68, 0.92);
+}
+
+.toast[data-type='error'] {
+  background: rgba(240, 62, 62, 0.92);
+}
+
+.empty {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 14px;
+}
+
+@media (max-width: 960px) {
+  .hero {
     grid-template-columns: 1fr;
+    text-align: left;
   }
 
-  .app-aside {
-    order: 2;
-  }
-
-  .chat-panel {
-    order: 1;
-    min-height: 50vh;
+  .hero-stats {
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   }
 }
 
-@media (max-width: 600px) {
-  .app-shell {
-    padding: 16px;
+@media (max-width: 720px) {
+  .page-shell {
+    padding: 24px 18px 36px;
   }
 
-  .app-header {
+  .hero {
+    padding: 32px 24px;
+  }
+
+  .announcement-section,
+  .service-section,
+  .canteen-section,
+  .ondemand-section,
+  .support-section {
+    padding: 24px;
+  }
+
+  .contact-fab {
+    right: 18px;
+    bottom: 18px;
+  }
+}
+
+@media (max-width: 520px) {
+  .search-box {
+    width: 100%;
+    min-width: unset;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  button.primary {
+    width: 100%;
+  }
+
+  .floor-summary {
     flex-direction: column;
     align-items: flex-start;
-    gap: 12px;
+  }
+
+  .contact-form {
+    padding: 24px 20px;
   }
 }

--- a/server.js
+++ b/server.js
@@ -5,9 +5,206 @@ const url = require('url');
 
 const PORT = process.env.PORT || 3000;
 const PUBLIC_DIR = path.join(__dirname, 'public');
-const clients = new Set();
-const messages = [];
-const MAX_MESSAGES = 200;
+const MAX_BODY_SIZE = 1e6; // 1MB
+
+const homeData = {
+  hero: {
+    brand: '云速达 · 微校园',
+    slogan: '一站式校园生活服务，用心守护每一个紧急时刻',
+    stats: {
+      completedOrdersToday: 126,
+      averageDeliveryMinutes: 18,
+      serviceSatisfaction: 98
+    }
+  },
+  announcements: [
+    {
+      id: 'a1',
+      title: '午高峰档口加开窗口',
+      description: '食堂一楼今日 11:30-13:30 将增开 2 个取餐窗口，请大家按指引排队。',
+      date: '05-18',
+      level: 'info'
+    },
+    {
+      id: 'a2',
+      title: '图书馆打印优惠',
+      description: '5 月学习季，持学生证前往智慧打印点可享黑白打印 8 折优惠。',
+      date: '05-18',
+      level: 'success'
+    },
+    {
+      id: 'a3',
+      title: '夜间跑腿温馨提示',
+      description: '23:00 后下单请在备注中标明宿舍楼与寝室号，便于骑手快速送达。',
+      date: '05-17',
+      level: 'warning'
+    }
+  ],
+  categories: [
+    {
+      id: 'canteen-market',
+      name: '食堂超市',
+      description: '热餐速递、零食饮料即时达',
+      icon: '🍱',
+      accent: 'linear-gradient(135deg,#ff9a9e,#fad0c4)'
+    },
+    {
+      id: 'document-print',
+      name: '文件打印',
+      description: '云端上传 极速取件',
+      icon: '🖨️',
+      accent: 'linear-gradient(135deg,#a18cd1,#fbc2eb)'
+    },
+    {
+      id: 'second-hand',
+      name: '二手市场',
+      description: '闲置书本 秒上新',
+      icon: '📚',
+      accent: 'linear-gradient(135deg,#f6d365,#fda085)'
+    },
+    {
+      id: 'errand',
+      name: '校园跑腿',
+      description: '代购代取 一键发布',
+      icon: '🏃‍♂️',
+      accent: 'linear-gradient(135deg,#5ee7df,#b490ca)'
+    },
+    {
+      id: 'express',
+      name: '快递到寝',
+      description: '免排队 专人送',
+      icon: '📦',
+      accent: 'linear-gradient(135deg,#cfd9df,#e2ebf0)'
+    },
+    {
+      id: 'repair',
+      name: '宿舍报修',
+      description: '水电网络 及时修',
+      icon: '🛠️',
+      accent: 'linear-gradient(135deg,#d4fc79,#96e6a1)'
+    },
+    {
+      id: 'study-room',
+      name: '自习预约',
+      description: '空余座位 实时看',
+      icon: '🪑',
+      accent: 'linear-gradient(135deg,#84fab0,#8fd3f4)'
+    },
+    {
+      id: 'lost-found',
+      name: '失物招领',
+      description: '失而复得 校务号',
+      icon: '🔍',
+      accent: 'linear-gradient(135deg,#fccb90,#d57eeb)'
+    }
+  ],
+  featuredFloors: [
+    {
+      id: 'floor-1',
+      name: '食堂一楼',
+      waiting: '平均出餐 6 分钟',
+      distance: '距你 350 米',
+      highlights: ['现煮粉面', '鲜榨果汁'],
+      stalls: [
+        {
+          id: 'stall-11',
+          name: '瓦香鸡米饭',
+          price: '¥12.80 起',
+          soldToday: 384,
+          tags: ['下单立减 ¥2', '约 20 分钟送达']
+        },
+        {
+          id: 'stall-12',
+          name: '老长沙大香肠',
+          price: '¥9.90 起',
+          soldToday: 241,
+          tags: ['新品热卖', '香辣/原味任选']
+        },
+        {
+          id: 'stall-13',
+          name: '鲜蔬手工饼',
+          price: '¥8.50 起',
+          soldToday: 198,
+          tags: ['芝士加倍', '自提免排队']
+        }
+      ]
+    },
+    {
+      id: 'floor-2',
+      name: '食堂二楼',
+      waiting: '平均出餐 8 分钟',
+      distance: '距你 410 米',
+      highlights: ['精品小炒', '盖码饭'],
+      stalls: [
+        {
+          id: 'stall-21',
+          name: '川香小炒肉',
+          price: '¥13.50 起',
+          soldToday: 305,
+          tags: ['下单返券', '双人套餐减 ¥5']
+        },
+        {
+          id: 'stall-22',
+          name: '汤鲜砂锅面',
+          price: '¥11.20 起',
+          soldToday: 276,
+          tags: ['可选微辣', '可预约取餐']
+        },
+        {
+          id: 'stall-23',
+          name: '锡纸花甲粉',
+          price: '¥12.00 起',
+          soldToday: 223,
+          tags: ['夜宵限定', '加料不加价']
+        }
+      ]
+    }
+  ],
+  onDemandServices: [
+    {
+      id: 'print-fast',
+      name: '云打印·智取柜',
+      icon: '🖨️',
+      eta: '最快 15 分钟',
+      price: '¥0.8/页 起',
+      description: '支持 PDF/图片在线上传，短信通知到柜取件。'
+    },
+    {
+      id: 'package-delivery',
+      name: '快递到寝',
+      icon: '🚲',
+      eta: '平均 25 分钟',
+      price: '¥3 起/件',
+      description: '小哥代排队领取快递，支持送到寝室门口。'
+    },
+    {
+      id: 'supermarket',
+      name: '超市急送',
+      icon: '🛒',
+      eta: '约 18 分钟',
+      price: '商品实价+跑腿费',
+      description: '夜宵零食、生活用品即刻下单即刻配送。'
+    },
+    {
+      id: 'document-run',
+      name: '教务跑腿',
+      icon: '📄',
+      eta: '工作时间专人处理',
+      price: '¥12 起',
+      description: '代办成绩单、盖章、缴费，实时同步进度。'
+    }
+  ],
+  contact: {
+    hotline: '400-889-7755',
+    wechat: 'yunxiaoyuan-service',
+    email: 'support@yunxiaoyuan.cn',
+    serviceHours: '周一至周日 07:30 - 23:30',
+    location: '校园综合服务中心 1 层 服务台',
+    notice: '提交表单后，客服将在 10 分钟内与您取得联系。'
+  }
+};
+
+const contactRequests = [];
 
 function getContentType(filePath) {
   const ext = path.extname(filePath).toLowerCase();
@@ -31,30 +228,105 @@ function getContentType(filePath) {
   }
 }
 
-function sendEvent(res, eventName, data) {
-  const payload = `event: ${eventName}\ndata: ${JSON.stringify(data)}\n\n`;
-  res.write(payload);
+function sendJSON(res, statusCode, payload) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json; charset=utf-8',
+    'Cache-Control': 'no-store',
+    'Access-Control-Allow-Origin': '*'
+  });
+  res.end(JSON.stringify(payload));
 }
 
-function broadcast(eventName, data) {
-  for (const client of clients) {
-    sendEvent(client, eventName, data);
-  }
-}
-
-function addMessage(message) {
-  messages.push(message);
-  while (messages.length > MAX_MESSAGES) {
-    messages.shift();
-  }
-  broadcast('message', message);
-}
-
-function sanitize(input, { maxLength = 200 } = {}) {
-  if (typeof input !== 'string') {
+function sanitize(value, { maxLength = 200 } = {}) {
+  if (value === undefined || value === null) {
     return '';
   }
-  return input.trim().slice(0, maxLength);
+  return String(value).trim().slice(0, maxLength);
+}
+
+function handleApi(req, res, parsedUrl) {
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+      'Access-Control-Allow-Headers': 'Content-Type'
+    });
+    res.end();
+    return true;
+  }
+
+  if (req.method === 'GET' && parsedUrl.pathname === '/api/home') {
+    const payload = {
+      ...homeData,
+      serverTime: new Date().toISOString(),
+      pendingContactCount: contactRequests.length
+    };
+    sendJSON(res, 200, payload);
+    return true;
+  }
+
+  if (req.method === 'POST' && parsedUrl.pathname === '/api/contact') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+      if (body.length > MAX_BODY_SIZE) {
+        body = '';
+        res.writeHead(413, { 'Content-Type': 'application/json; charset=utf-8' });
+        res.end(JSON.stringify({ error: '请求体过大' }));
+        req.connection.destroy();
+      }
+    });
+
+    req.on('end', () => {
+      if (!body) {
+        sendJSON(res, 400, { error: '请求体不能为空' });
+        return;
+      }
+
+      try {
+        const parsed = JSON.parse(body);
+        const name = sanitize(parsed.name, { maxLength: 32 });
+        const phone = sanitize(parsed.phone, { maxLength: 20 });
+        const serviceType = sanitize(parsed.serviceType, { maxLength: 50 });
+        const message = sanitize(parsed.message, { maxLength: 500 });
+
+        if (!name) {
+          sendJSON(res, 400, { error: '请填写您的姓名或昵称' });
+          return;
+        }
+        if (!message) {
+          sendJSON(res, 400, { error: '请填写您需要帮助的内容' });
+          return;
+        }
+        if (phone && !/^\+?[0-9\-\s]{5,20}$/.test(phone)) {
+          sendJSON(res, 400, { error: '联系方式格式不正确，请留下常用手机号或短号' });
+          return;
+        }
+
+        const ticket = Date.now().toString(36) + Math.random().toString(36).slice(2, 6);
+        contactRequests.push({
+          ticket,
+          name,
+          phone,
+          serviceType,
+          message,
+          createdAt: new Date().toISOString()
+        });
+
+        sendJSON(res, 201, {
+          status: 'ok',
+          ticket,
+          message: '已收到您的咨询，客服将在 10 分钟内联系您。'
+        });
+      } catch (error) {
+        sendJSON(res, 400, { error: '无法解析请求，请检查提交内容' });
+      }
+    });
+
+    return true;
+  }
+
+  return false;
 }
 
 function serveStatic(req, res) {
@@ -66,7 +338,7 @@ function serveStatic(req, res) {
 
   const filePath = path.join(PUBLIC_DIR, pathname);
   if (!filePath.startsWith(PUBLIC_DIR)) {
-    res.writeHead(403);
+    res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
     res.end('Forbidden');
     return;
   }
@@ -86,66 +358,21 @@ function serveStatic(req, res) {
 const server = http.createServer((req, res) => {
   const parsedUrl = url.parse(req.url, true);
 
-  if (req.method === 'GET' && parsedUrl.pathname === '/events') {
-    res.writeHead(200, {
-      'Content-Type': 'text/event-stream',
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive',
-      'Access-Control-Allow-Origin': '*'
-    });
-
-    sendEvent(res, 'history', messages);
-    res.write(': connected\n\n');
-
-    clients.add(res);
-    req.on('close', () => {
-      clients.delete(res);
-    });
-    return;
-  }
-
-  if (req.method === 'POST' && parsedUrl.pathname === '/message') {
-    let body = '';
-    req.on('data', chunk => {
-      body += chunk;
-      if (body.length > 1e6) {
-        req.connection.destroy();
-      }
-    });
-
-    req.on('end', () => {
-      try {
-        const parsed = JSON.parse(body || '{}');
-        const user = sanitize(parsed.user, { maxLength: 32 }) || '匿名用户';
-        const text = sanitize(parsed.text, { maxLength: 500 });
-
-        if (!text) {
-          res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' });
-          res.end(JSON.stringify({ error: '消息内容不能为空' }));
-          return;
-        }
-
-        const message = {
-          id: Date.now().toString(36) + Math.random().toString(36).slice(2, 8),
-          user,
-          text,
-          timestamp: new Date().toISOString()
-        };
-
-        addMessage(message);
-        res.writeHead(201, { 'Content-Type': 'application/json; charset=utf-8' });
-        res.end(JSON.stringify({ status: 'ok' }));
-      } catch (error) {
-        res.writeHead(400, { 'Content-Type': 'application/json; charset=utf-8' });
-        res.end(JSON.stringify({ error: '无法解析请求' }));
-      }
-    });
+  if (parsedUrl.pathname && parsedUrl.pathname.startsWith('/api/')) {
+    const handled = handleApi(req, res, parsedUrl);
+    if (handled) {
+      return;
+    }
+    sendJSON(res, 404, { error: '接口未找到' });
     return;
   }
 
   if (req.method === 'GET' && parsedUrl.pathname === '/health') {
-    res.writeHead(200, { 'Content-Type': 'application/json; charset=utf-8' });
-    res.end(JSON.stringify({ status: 'ok', clients: clients.size, messages: messages.length }));
+    sendJSON(res, 200, {
+      status: 'ok',
+      uptime: process.uptime(),
+      pendingContactCount: contactRequests.length
+    });
     return;
   }
 
@@ -153,5 +380,5 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(PORT, () => {
-  console.log(`Super System chat server is running at http://localhost:${PORT}`);
+  console.log(`Campus service portal is running at http://localhost:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- replace the former chat UI with a campus-service themed landing page featuring announcements, hot services, food stalls, and errands
- expose new `/api/home` data and a `/api/contact` submission endpoint with in-memory storage and validation
- implement a customer service dialog, global search filtering, and refreshed styling for a polished mini-program experience

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68f06169870483318188b6d45ee6e189